### PR TITLE
Modifications for PR #245

### DIFF
--- a/cstar/roms/runtime_settings.py
+++ b/cstar/roms/runtime_settings.py
@@ -813,20 +813,3 @@ class ROMSRuntimeSettings(BaseModel):
 
         with Path(filepath).open("w") as f:
             f.write(self.model_dump())
-
-
-if __name__ == "__main__":
-    orig = "/Users/eilerman/Downloads/sje_pacmed12km_Y2000.in"
-    r = ROMSRuntimeSettings.from_file(orig)
-    # print(r)
-    new = "./new.in"
-    r.to_file(new)  # noqa
-
-    with open(new, "r") as f:
-        lines_new = f.readlines()
-    with open(orig, "r") as f:
-        lines_orig = f.readlines()
-
-    r2 = ROMSRuntimeSettings.from_file(new)
-    assert r == r2
-    # assert lines_orig == lines_new

--- a/cstar/roms/runtime_settings.py
+++ b/cstar/roms/runtime_settings.py
@@ -34,24 +34,9 @@ CUSTOM_ALIAS_LOOKUP = {
     "initial_conditions": "initial",
 }
 
-# def _format_list_of_floats(float_list: list[float]) -> str:
-#     delimiter = " "
-#     return delimiter.join(_format_float(x) for x in float_list)
-#
-#
-# def _format_list_of_paths(
-#     path_list: list[Path], multi_line: Optional[bool] = False
-# ) -> str:
-#     delimiter = "\n    " if multi_line else " "
-#     return delimiter.join(_format_path(x) for x in path_list)
-#
-#
-# def _format_list_of_other(other_list: list[str | int]) -> str:
-#     delimiter = " "
-#     return delimiter.join(_format_other(x) for x in other_list)
-
 
 def _format_float(val: float) -> str:
+    """Apply special float formatting for 0 and scientific notation."""
     if val == 0.0:
         return "0."
 
@@ -62,6 +47,8 @@ def _format_float(val: float) -> str:
 
 
 def _format_value(val: Any) -> str:
+    """Format floats using _format_float, otherwise just return the string of the
+    value."""
     if isinstance(val, float):
         return _format_float(val)
     return str(val)
@@ -140,6 +127,8 @@ class ROMSRuntimeSettingsSection(BaseModel, abc.ABC):
 
     @property
     def key_order(self):
+        """Return the pydantic fields (no class vars or properties) in the order they
+        are specified."""
         return list(self.__pydantic_fields__.keys())
 
     @model_validator(mode="wrap")
@@ -384,7 +373,7 @@ class InitialConditions(ROMSRuntimeSettingsSection):
         if (not lines) or (len(lines) == 1) and int(lines[0]) == 0:
             return cls(nrrec=0, ininame=None)
         else:
-            return super(InitialConditions, cls).from_lines(lines)
+            return super().from_lines(lines)
 
 
 class Forcing(ROMSRuntimeSettingsSection):

--- a/cstar/roms/runtime_settings.py
+++ b/cstar/roms/runtime_settings.py
@@ -445,11 +445,12 @@ class ROMSRuntimeSettings(BaseModel):
     forcing: Forcing
     output_root_name: OutputRootName
 
-    rho0: Optional[Rho0] = None
-    marbl_biogeochemistry: Optional[MARBLBiogeochemistry] = None
     s_coord: Optional[SCoord] = None
-    lin_rho_eos: Optional[LinRhoEos] = None
+    grid: Optional[Grid] = None
+    marbl_biogeochemistry: Optional[MARBLBiogeochemistry] = None
     lateral_visc: Optional[LateralVisc] = None
+    rho0: Optional[Rho0] = None
+    lin_rho_eos: Optional[LinRhoEos] = None
     gamma2: Optional[Gamma2] = None
     tracer_diff2: Optional[TracerDiff2] = None
     vertical_mixing: Optional[VerticalMixing] = None
@@ -458,7 +459,6 @@ class ROMSRuntimeSettings(BaseModel):
     sst_correction: Optional[SSTCorrection] = None
     ubind: Optional[UBind] = None
     v_sponge: Optional[VSponge] = None
-    grid: Optional[Grid] = None
     climatology: Optional[Climatology] = None
 
     # Pydantic model configuration
@@ -799,7 +799,7 @@ class ROMSRuntimeSettings(BaseModel):
             if section is None:
                 continue
             output += section.model_dump()
-            output += "\n"
+
         return output
 
     def to_file(self, filepath: str | Path) -> None:

--- a/cstar/roms/runtime_settings.py
+++ b/cstar/roms/runtime_settings.py
@@ -847,20 +847,3 @@ class ROMSRuntimeSettings(BaseModel):
 
         with Path(filepath).open("w") as f:
             f.write(self.model_dump())
-
-
-if __name__ == "__main__":
-    orig = "/Users/eilerman/Downloads/sje_pacmed12km_Y2000.in"
-    r = ROMSRuntimeSettings.from_file(orig)
-    # print(r)
-    new = "./new.in"
-    r.to_file(new)  # noqa
-
-    with open(new, "r") as f:
-        lines_new = f.readlines()
-    with open(orig, "r") as f:
-        lines_orig = f.readlines()
-
-    r2 = ROMSRuntimeSettings.from_file(new)
-    assert r == r2
-    # assert lines_orig == lines_new

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -1442,8 +1442,8 @@ class ROMSSimulation(Simulation):
         else:  # cstar_sysmgr.scheduler is None
             romsprocess = LocalProcess(commands=roms_exec_cmd, run_path=run_path)
             self._execution_handler = romsprocess
-            romsprocess.start()
             self.persist()
+            romsprocess.start()
             return romsprocess
 
     def post_run(self) -> None:

--- a/cstar/roms/simulation.py
+++ b/cstar/roms/simulation.py
@@ -276,16 +276,16 @@ class ROMSSimulation(Simulation):
         """
 
         in_files = [f for f in self.runtime_code.files if f.endswith(".in")]
-        if len(in_files) != 1:
-            raise RuntimeError(
-                "ROMS requires exactly one runtime settings "
-                + "file (with a `.in` extension), e.g. `roms.in`. "
-                + "Supplied files: \n"
-                + "\n".join(self.runtime_code.files)
-            )
+
+        if not in_files:
+            raise RuntimeError("No .in file was provided")
+
+        if len(in_files) > 1:
+            raise RuntimeError(f"Only 1 .in file is allowed. Got: {in_files}")
+
         self._in_file = in_files[0]
 
-    def _check_forcing_collection_types(self, collection, expected_class):
+    def _check_forcing_collection_types(self, collection: list, expected_class: type):
         """Validate the types of input datasets in a forcing collection.
 
         For forcing types that may correspond to multiple ROMSInputDataset instances
@@ -627,20 +627,15 @@ class ROMSSimulation(Simulation):
             self.runtime_code.working_path / self._in_file
         )
 
-        # Previous modifications
-        # Time step entry
+        # Modify each relevant section in the runtime settings object based on blueprint values
         simulation_runtime_settings.time_stepping.dt = self.discretization.time_step
-
-        # ntimesteps entry:
         simulation_runtime_settings.time_stepping.ntimes = self._n_time_steps
 
-        # Initial conditions entry
         if self.initial_conditions:
             simulation_runtime_settings.initial.ininame = (
                 self.initial_conditions.path_for_roms[0]
             )
 
-        # Grid entry
         if self.model_grid:
             simulation_runtime_settings.grid = cstar.roms.runtime_settings.Grid(
                 grid=self.model_grid.path_for_roms[0]
@@ -648,10 +643,9 @@ class ROMSSimulation(Simulation):
         else:
             simulation_runtime_settings.grid = None
 
-        # Forcing
         simulation_runtime_settings.forcing.filenames = self._forcing_paths
-        # MARBL settings:
 
+        # all MARBL files must be present to enable MARBL
         if all(
             f in self.runtime_code.files
             for f in [
@@ -1385,22 +1379,22 @@ class ROMSSimulation(Simulation):
         if self.exe_path is None:
             raise ValueError(
                 "C-STAR: ROMSSimulation.exe_path is None; unable to find ROMS executable."
-                + "\nRun Simulation.build() first. "
-                + "\n If you have already run Simulation.build(), either run it again or "
-                + " add the executable path manually using Simulation.exe_path='YOUR/PATH'."
+                "\nRun Simulation.build() first. "
+                "\n If you have already run Simulation.build(), either run it again or "
+                " add the executable path manually using Simulation.exe_path='YOUR/PATH'."
             )
 
         if self.discretization.n_procs_tot is None:
             raise ValueError(
                 "Unable to calculate node distribution for this Simulation. "
-                + "Simulation.n_procs_tot is not set"
+                "Simulation.n_procs_tot is not set"
             )
 
         if self.runtime_code.working_path is None:
             raise FileNotFoundError(
                 "Local copy of ROMSSimulation.runtime_code does not exist. "
-                + "Call ROMSSimulation.setup() or ROMSSimulation.runtime_code.get() "
-                + "and try again"
+                "Call ROMSSimulation.setup() or ROMSSimulation.runtime_code.get() "
+                "and try again"
             )
 
         if (queue_name is None) and (cstar_sysmgr.scheduler is not None):
@@ -1408,23 +1402,20 @@ class ROMSSimulation(Simulation):
         if (walltime is None) and (cstar_sysmgr.scheduler is not None):
             walltime = cstar_sysmgr.scheduler.get_queue(queue_name).max_walltime
 
-        output_dir = self.directory / "output"
-
-        # Set run path to output dir for clarity: we are running in the output dir but
-        # these are conceptually different:
-        run_path = output_dir
+        # we run ROMS in the output dir
+        run_path = self.directory / "output"
 
         final_runtime_settings_file = (
             self.runtime_code.working_path.resolve() / f"{self.name}.in"
         )
         self.roms_runtime_settings.to_file(final_runtime_settings_file)
-        output_dir.mkdir(parents=True, exist_ok=True)
+        run_path.mkdir(parents=True, exist_ok=True)
 
         ## 2: RUN ROMS
 
         roms_exec_cmd = (
             f"{cstar_sysmgr.environment.mpi_exec_prefix} -n {self.discretization.n_procs_tot} {self.exe_path} "
-            + f"{final_runtime_settings_file}"
+            f"{final_runtime_settings_file}"
         )
 
         if cstar_sysmgr.scheduler is not None:
@@ -1445,15 +1436,15 @@ class ROMSSimulation(Simulation):
 
             job_instance.submit()
             self._execution_handler = job_instance
+            self.persist()
             return job_instance
 
         else:  # cstar_sysmgr.scheduler is None
             romsprocess = LocalProcess(commands=roms_exec_cmd, run_path=run_path)
             self._execution_handler = romsprocess
             romsprocess.start()
+            self.persist()
             return romsprocess
-
-        self.persist()
 
     def post_run(self) -> None:
         """Perform post-processing steps after the ROMS simulation run.

--- a/cstar/tests/unit_tests/roms/fixtures/example_runtime_settings.in
+++ b/cstar/tests/unit_tests/roms/fixtures/example_runtime_settings.in
@@ -31,9 +31,6 @@ MARBL_biogeochemistry: marbl_namelist_fname marbl_tracer_list_fname marbl_diag_l
     marbl_tracer_list_fname
     marbl_diagnostic_output_list
 
-lateral_visc: lateral_visc
-    0.
-
 rho0: rho0
     1000.0
 
@@ -60,9 +57,6 @@ sst_correction: sst_correction
 
 ubind: ubind
     0.1
-
-v_sponge: v_sponge
-    0.
 
 climatology: climatology
     climfile2.nc

--- a/cstar/tests/unit_tests/roms/fixtures/example_runtime_settings.in
+++ b/cstar/tests/unit_tests/roms/fixtures/example_runtime_settings.in
@@ -1,15 +1,19 @@
 title: title
     Example runtime settings
 
+
 time_stepping: ntimes dt ndtfast ninfo
     360    60    60    1
+
 
 bottom_drag: rdrg rdrg2 zob
     0.    1.000000E-03    0.01
 
+
 initial: nrrec ininame
     1
     input_datasets/roms_ini.nc
+
 
 forcing: filenames
     input_datasets/roms_frc.nc
@@ -17,47 +21,70 @@ forcing: filenames
     input_datasets/roms_bry.nc
     input_datasets/roms_bry_bgc.nc
 
+
 output_root_name: output_root_name
     ROMS_test
 
-S-coord: theta_s theta_b tcline
-    5.0    2.0    300.0
 
-grid: grid
-    input_datasets/roms_grd.nc
+rho0: rho0
+    1000.0
+
 
 MARBL_biogeochemistry: marbl_namelist_fname marbl_tracer_list_fname marbl_diag_list_fname
     marbl_in
     marbl_tracer_list_fname
     marbl_diagnostic_output_list
 
-rho0: rho0
-    1000.0
+
+S-coord: theta_s theta_b tcline
+    5.0    2.0    300.0
+
 
 lin_rho_eos: Tcoef T0 Scoef S0
     0.2    1.0    0.822    1.0
 
+
+lateral_visc: lateral_visc
+    0.
+
+
 gamma2: gamma2
     1.0
+
 
 tracer_diff2: tracer_diff2
     0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.
 
+
 vertical_mixing: Akv_bak Akt_bak
     0.    0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.
+
 
 MY_bak_mixing: Akq_bak q2nu2 q2nu4
     1.000000E-05    0.    0.
 
+
 sss_correction: sss_correction
     7.777
+
 
 sst_correction: sst_correction
     10.0
 
+
 ubind: ubind
     0.1
 
+
+v_sponge: v_sponge
+    0.
+
+
+grid: grid
+    input_datasets/roms_grd.nc
+
+
 climatology: climatology
     climfile2.nc
+
 

--- a/cstar/tests/unit_tests/roms/fixtures/example_runtime_settings.in
+++ b/cstar/tests/unit_tests/roms/fixtures/example_runtime_settings.in
@@ -1,19 +1,15 @@
 title: title
     Example runtime settings
 
-
 time_stepping: ntimes dt ndtfast ninfo
     360    60    60    1
-
 
 bottom_drag: rdrg rdrg2 zob
     0.    1.000000E-03    0.01
 
-
 initial: nrrec ininame
     1
     input_datasets/roms_ini.nc
-
 
 forcing: filenames
     input_datasets/roms_frc.nc
@@ -21,70 +17,53 @@ forcing: filenames
     input_datasets/roms_bry.nc
     input_datasets/roms_bry_bgc.nc
 
-
 output_root_name: output_root_name
     ROMS_test
 
+S-coord: theta_s theta_b tcline
+    5.0    2.0    300.0
 
-rho0: rho0
-    1000.0
-
+grid: grid
+    input_datasets/roms_grd.nc
 
 MARBL_biogeochemistry: marbl_namelist_fname marbl_tracer_list_fname marbl_diag_list_fname
     marbl_in
     marbl_tracer_list_fname
     marbl_diagnostic_output_list
 
+lateral_visc: lateral_visc
+    0.
 
-S-coord: theta_s theta_b tcline
-    5.0    2.0    300.0
-
+rho0: rho0
+    1000.0
 
 lin_rho_eos: Tcoef T0 Scoef S0
     0.2    1.0    0.822    1.0
 
-
-lateral_visc: lateral_visc
-    0.
-
-
 gamma2: gamma2
     1.0
-
 
 tracer_diff2: tracer_diff2
     0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.
 
-
 vertical_mixing: Akv_bak Akt_bak
     0.    0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0. 0.
-
 
 MY_bak_mixing: Akq_bak q2nu2 q2nu4
     1.000000E-05    0.    0.
 
-
 sss_correction: sss_correction
     7.777
-
 
 sst_correction: sst_correction
     10.0
 
-
 ubind: ubind
     0.1
-
 
 v_sponge: v_sponge
     0.
 
-
-grid: grid
-    input_datasets/roms_grd.nc
-
-
 climatology: climatology
     climfile2.nc
-
 

--- a/cstar/tests/unit_tests/roms/test_roms_runtime_settings.py
+++ b/cstar/tests/unit_tests/roms/test_roms_runtime_settings.py
@@ -206,23 +206,25 @@ class TestROMSRuntimeSettingsSection:
         assert section.val2 == "hello"
 
     def test_format_list_of_floats(self):
-        lf = EmptySection()._formatted_joiner([1e-3, 0.0, 2])
+        lf = EmptySection()._format_and_join_values([1e-3, 0.0, 2])
         assert lf == "1.000000E-03 0. 2"
 
     def test_format_path(self):
-        p = EmptySection()._formatted_joiner(Path("mypath.nc"))
+        p = EmptySection()._format_and_join_values(Path("mypath.nc"))
         assert p == "mypath.nc"
 
     def test_format_list_of_paths(self):
-        lp = EmptySection()._formatted_joiner([Path("path1.nc"), Path("path2.nc")])
+        lp = EmptySection()._format_and_join_values(
+            [Path("path1.nc"), Path("path2.nc")]
+        )
         assert lp == "path1.nc path2.nc"
 
     @pytest.mark.parametrize("o,st", [(5, "5"), ("helloworld", "helloworld")])
     def test_format_other(self, o, st):
-        assert EmptySection()._formatted_joiner(o) == st
+        assert EmptySection()._format_and_join_values(o) == st
 
     def test_format_list_of_other(self):
-        o = EmptySection()._formatted_joiner([5, "foo"])
+        o = EmptySection()._format_and_join_values([5, "foo"])
         assert o == "5 foo"
 
     def test_validate_from_lines_calls_from_lines(self):

--- a/cstar/tests/unit_tests/roms/test_roms_runtime_settings.py
+++ b/cstar/tests/unit_tests/roms/test_roms_runtime_settings.py
@@ -356,12 +356,6 @@ class TestSingleEntryROMSRuntimeSettingsSection:
     class MockSingleEntrySection(SingleEntryROMSRuntimeSettingsSection):
         value: float
 
-    def test_init_subclass_sets_attrs(self):
-        """Tests that SingleEntryROMSRuntimeSettingsSection.__init_subclass__ correctly
-        sets the section_name and key_order attributes."""
-        # assert self.MockSingleEntrySection.section_name == "value"
-        assert self.MockSingleEntrySection.key_order == ["value"]
-
     def test_single_entry_validator_returns_cls_when_type_matches(self):
         """Tests that the `single_entry_validator` method passes a correctly typed value
         to cls() without requiring a dict or kwargs for initialization."""
@@ -396,11 +390,13 @@ class TestSingleEntryROMSRuntimeSettingsSection:
     def test_single_entry_section_raises_if_multiple_fields(self):
         """Tests that attempting to initialize a SingleEntryROMSRuntimeSettingsSection
         with multiple entries raises a TypeError."""
-        with pytest.raises(TypeError, match="must declare exactly one field"):
+        with pytest.raises(TypeError):
 
             class InvalidSection(SingleEntryROMSRuntimeSettingsSection):
                 a: int
                 b: float
+
+            InvalidSection(a=1, b=2)
 
 
 class TestROMSRuntimeSettings:

--- a/cstar/tests/unit_tests/roms/test_roms_runtime_settings.py
+++ b/cstar/tests/unit_tests/roms/test_roms_runtime_settings.py
@@ -79,15 +79,15 @@ def example_runtime_settings():
 class MockSection(ROMSRuntimeSettingsSection):
     """A simple ROMSRuntimeSettingsSection subclass for testing."""
 
-    section_name = "test_section"
-    key_order = [
-        "floats",  # list[float]
-        "paths",  # list[Path]
-        "others",  # list[str|int]
-        "floatval",  # float
-        "pathval",  # Path
-        "otherval",  # str (fallback case)
-    ]
+    _section_name = "test_section"
+    # key_order = [
+    #     "floats",  # list[float]
+    #     "paths",  # list[Path]
+    #     "others",  # list[str|int]
+    #     "floatval",  # float
+    #     "pathval",  # Path
+    #     "otherval",  # str (fallback case)
+    # ]
 
     floats: list[float]
     paths: list[Path]
@@ -172,8 +172,8 @@ class TestROMSRuntimeSettingsSection:
         """Test ROMSRuntimeSettingsSection.__init__ with *args instead of **kwargs."""
 
         class TestSection(ROMSRuntimeSettingsSection):
-            section_name = "test_section"
-            key_order = ["val1", "val2"]
+            _section_name = "test_section"
+            # key_order = ["val1", "val2"]
             val1: float
             val2: str
 
@@ -250,8 +250,8 @@ class TestROMSRuntimeSettingsSection:
         correctly returned by `from_lines` with fortran-style formatting."""
 
         class FloatSection(ROMSRuntimeSettingsSection):
-            section_name = "float_section"
-            key_order = ["val"]
+            _section_name = "float_section"
+            # key_order = ["val"]
             val: float
 
         section = FloatSection.from_lines(["5.0D0"])
@@ -262,8 +262,8 @@ class TestROMSRuntimeSettingsSection:
         returned by `from_lines`"""
 
         class MixedSection(ROMSRuntimeSettingsSection):
-            section_name = "mixed"
-            key_order = ["count", "name"]
+            _section_name = "mixed"
+            # key_order = ["count", "name"]
             count: int
             name: str
 
@@ -276,8 +276,8 @@ class TestROMSRuntimeSettingsSection:
         the final entry is a list (using all remaining values to populate it)"""
 
         class ListAtEnd(ROMSRuntimeSettingsSection):
-            section_name = "list_end"
-            key_order = ["prefix", "items"]
+            _section_name = "list_end"
+            # key_order = ["prefix", "items"]
             prefix: str
             items: list[int]
 
@@ -290,8 +290,8 @@ class TestROMSRuntimeSettingsSection:
         instance when the only entry is a list."""
 
         class OnlyList(ROMSRuntimeSettingsSection):
-            section_name = "only_list"
-            key_order = ["entries"]
+            _section_name = "only_list"
+            # key_order = ["entries"]
             entries: list[str]
 
         section = OnlyList.from_lines(["a b c"])
@@ -302,9 +302,9 @@ class TestROMSRuntimeSettingsSection:
         where entries are on different lines."""
 
         class MultiLinePaths(ROMSRuntimeSettingsSection):
-            section_name = "files"
+            _section_name = "files"
             multi_line = True
-            key_order = ["paths"]
+            # key_order = ["paths"]
             paths: list[Path]
 
         section = MultiLinePaths.from_lines(["a.nc", "b.nc", "c.nc"])
@@ -359,7 +359,7 @@ class TestSingleEntryROMSRuntimeSettingsSection:
     def test_init_subclass_sets_attrs(self):
         """Tests that SingleEntryROMSRuntimeSettingsSection.__init_subclass__ correctly
         sets the section_name and key_order attributes."""
-        assert self.MockSingleEntrySection.section_name == "value"
+        # assert self.MockSingleEntrySection.section_name == "value"
         assert self.MockSingleEntrySection.key_order == ["value"]
 
     def test_single_entry_validator_returns_cls_when_type_matches(self):


### PR DESCRIPTION
quick overview:
- addresses most PR comments on https://github.com/CWorthy-ocean/C-Star/pull/245
- favors consolidation of functionality vs. explicitness, e.g. use pydantic field declaration order for key order, unify formatters, cleaner handling of section naming.
- removed __init_sublcass__ because it scares me and ended up being unnecessary with the other changes. went with metaclasses in an earlier draft, but was able to go without it.


- [ ] Closes #xxxx
- [x] Tests added
- [x] Tests passing
- [x] Full type hint coverage
- [ ] Changes are documented in `docs/releases.rst`
- [ ] New functions/methods are listed in `api.rst`
- [ ] New functionality has documentation