### PR TITLE
example of more code on FileInfo class

### DIFF
--- a/cstar/base/local_file_stats.py
+++ b/cstar/base/local_file_stats.py
@@ -6,13 +6,57 @@ from pathlib import Path
 from typing import Optional
 
 from cstar.base.utils import _get_sha256_hash
+from cstar.base.log import get_logger
 
+logger = get_logger(__name__)
 
-@dataclass
 class FileInfo:
-    path: Path
-    stat: Optional[os.stat_result] = None
-    sha256: Optional[str] = None
+
+    def __init__(self, path: Path|str, stat: os.stat_result | None = None, sha256: str | None = None):
+
+        self.path = Path(path).absolute()
+        self._stat = stat
+        self._sha256 = sha256
+
+    @property
+    def stat(self) -> os.stat_result:
+        if self._stat is None:
+            self._stat = self.path.stat()
+        return self._stat
+
+    @property
+    def sha256(self) -> str:
+        if self._sha256 is None:
+            self._sha256 = _get_sha256_hash(self.path)
+        return self._sha256
+
+    def validate(self) -> bool:
+        if not self.path.exists():
+            raise FileNotFoundError(f"File {self.path} does not exist locally")
+
+        current_stat = self.path.stat()
+
+        if not self._stat:
+            logger.debug(f"File {self.path} has no cached stat")
+            self._stat = current_stat
+        else:
+
+            if (
+                current_stat.st_size != self.stat.st_size
+                or current_stat.st_mtime != self.stat.st_mtime
+            ):
+                raise ValueError(f"File statistics for {self.path} do not match those in cache")
+
+        current_hash = _get_sha256_hash(self.path)
+        if not self._sha256:
+            logger.debug(f"File {self.path} has no cached hash")
+        else:
+
+            if current_hash != self.sha256:
+                raise ValueError(
+                    f"Computed SHA256 hash for {self.path} ({current_hash}) does not "
+                    f"match value in cache ({self.sha256})"
+                )
 
 
 class LocalFileStatistics:
@@ -80,9 +124,7 @@ class LocalFileStatistics:
             raise ValueError("At least one file must be provided.")
 
         # Initialize attributes
-        self._stat_cache: dict[Path, os.stat_result] = {}
-        self._hash_cache: dict[Path, str] = {}
-        self.paths: list[Path] = []
+        self.files: dict[Path, FileInfo] = {}
 
         # Normalize files to all be FileInfo instances:
         def to_fileinfo(item: Path | FileInfo) -> FileInfo:
@@ -90,25 +132,30 @@ class LocalFileStatistics:
                 return item
             return FileInfo(path=item)
 
-        normalized_files = [to_fileinfo(f) for f in files]
+        self.files: dict[Path: FileInfo] = {f: to_fileinfo(f) for f in files}
 
         # For checking all files are colocated with the first:
-        first_parent = normalized_files[0].path.absolute().parent
+        first_parent = self.paths[0].parent
 
-        for f in normalized_files:
-            abs_path = f.path.absolute()
+        for f in self.paths:
 
-            if abs_path.parent != first_parent:
+            if f.parent != first_parent:
                 raise ValueError("All files must be in the same directory")
 
-            self.paths.append(abs_path)
-
-            if f.stat is not None:
-                self._stat_cache[abs_path] = f.stat
-            if f.sha256 is not None:
-                self._hash_cache[abs_path] = f.sha256
-
         self.parent_dir: Path = first_parent
+
+    @property
+    def paths(self) -> list[Path]:
+        return [f.path for f in self.files.values()]
+
+    @property
+    def stats(self) -> list[os.stat_result]:
+        return [f.stat for f in self.files.values()]
+
+    @property
+    def hashes(self) -> list[str]:
+        return [f.sha256 for f in self.files.values()]
+
 
     def __getitem__(self, key: str | Path) -> FileInfo:
         path = Path(key).absolute()
@@ -116,48 +163,8 @@ class LocalFileStatistics:
         if path not in self.paths:
             raise KeyError(f"{path} not found.")
 
-        return FileInfo(
-            path=path,
-            stat=self.stats[path],
-            sha256=self.hashes[path],
-        )
+        return self.files[path]
 
-    @property
-    def stats(self) -> dict[Path, os.stat_result]:
-        """File stat metadata for each tracked file.
-
-        Lazily computes and caches the output of `os.stat()` for each tracked
-        file path if not already provided. Returned as a dictionary mapping
-        absolute file paths to their `os.stat_result` values.
-
-        Returns
-        -------
-        dict of Path to os.stat_result
-            Mapping from file paths to their stat metadata.
-        """
-        if not self._stat_cache:
-            self._stat_cache = {path: path.stat() for path in self.paths}
-        return self._stat_cache
-
-    @property
-    def hashes(self) -> dict[Path, str]:
-        """SHA-256 hashes for each tracked file.
-
-        Lazily computes and caches the SHA-256 hash for each file using
-        `_get_sha256_hash()` if not already provided. Returned as a dictionary
-        mapping absolute file paths to their hash strings.
-
-        Returns
-        -------
-        dict of Path to str
-            Mapping from file paths to their SHA-256 hash values.
-        """
-
-        if not self._hash_cache:
-            self._hash_cache = {
-                path: _get_sha256_hash(path.resolve()) for path in self.paths
-            }
-        return self._hash_cache
 
     def validate(self) -> None:
         """Validate that all tracked files exist and match cached metadata.
@@ -174,26 +181,8 @@ class LocalFileStatistics:
             If the current size, modification time, or SHA-256 hash of a file
             differs from the cached value.
         """
+        [f.validate() for f in self.files.values()]
 
-        for f in self.paths:
-            if not f.exists():
-                raise FileNotFoundError(f"File {f} does not exist locally")
-
-            cached_stats = self.stats[f]
-            current_stats = f.stat()
-
-            if (
-                current_stats.st_size != cached_stats.st_size
-                or current_stats.st_mtime != cached_stats.st_mtime
-            ):
-                raise ValueError(f"File statistics for {f} do not match those in cache")
-
-            current_hash = _get_sha256_hash(f)
-            if current_hash != self.hashes[f]:
-                raise ValueError(
-                    f"Computed SHA256 hash for {f} ({current_hash}) does not "
-                    f"match value in cache ({self.hashes[f]})"
-                )
 
     def __str__(self) -> str:
         base_str = self.__class__.__name__ + "\n"
@@ -227,21 +216,19 @@ class LocalFileStatistics:
         header = f"{'Name':<40} {'Hash':<12} {'Size (bytes)':<12} {'Modified'}"
         rows = []
 
-        for path in self.paths[:max_rows]:
-            abspath = path.absolute()
-            stat = self.stats.get(abspath)
-            hash_ = self.hashes.get(abspath)
+        for p in self.paths[:max_rows]:
+            fi = self.files[p]
+            abspath = fi.path
+            stat = fi.stat
+            hash_ = fi.sha256
 
-            name = str(path.name)
-            size = stat.st_size if stat else "UNKNOWN"
-            mtime = (
-                datetime.fromtimestamp(stat.st_mtime).isoformat(
+            name = str(abspath.name)
+            size = stat.st_size
+            mtime = datetime.fromtimestamp(stat.st_mtime).isoformat(
                     sep=" ", timespec="seconds"
                 )
-                if stat
-                else "UNKNOWN"
-            )
-            short_hash = hash_[:10] + "…" if hash_ else "UNKNOWN"
+
+            short_hash = hash_[:10] + "…"
 
             rows.append(f"{name:<40} {short_hash:<12} {size:<12} {mtime}")
 

--- a/cstar/tests/unit_tests/base/test_local_file_stats.py
+++ b/cstar/tests/unit_tests/base/test_local_file_stats.py
@@ -69,8 +69,6 @@ class TestLocalFileStatisticsInit:
 
         assert lfs.paths == [file1.resolve(), file2.resolve()]
         assert lfs.parent_dir.resolve() == file1.parent
-        assert lfs._stat_cache == {}
-        assert lfs._hash_cache == {}
 
     def test_init_raises_if_paths_not_colocated(self, tmp_path):
         """Raise ValueError if paths do not share a common parent directory.
@@ -125,11 +123,9 @@ class TestLocalFileStatisticsInit:
 
         lfs = LocalFileStatistics(files=[fileinfo1, fileinfo2])
 
-        expected_stats = {file1: stat1, file2: stat2}
-        expected_hashes = {file1: hash1, file2: hash2}
+        expected_stats = [stat1, stat2]
+        expected_hashes = [hash1, hash2]
 
-        assert lfs._stat_cache == expected_stats
-        assert lfs._hash_cache == expected_hashes
         assert lfs.stats == expected_stats
         assert lfs.hashes == expected_hashes
 
@@ -174,11 +170,10 @@ class TestStatsAndHasesProperties:
         mock_hash.side_effect = ["fakehash1", "fakehash2"]
 
         lfs = LocalFileStatistics(files=[file1, file2])
-        assert lfs._hash_cache == {}
 
         hashes = lfs.hashes
-        assert hashes[file1.resolve()] == "fakehash1"
-        assert hashes[file2.resolve()] == "fakehash2"
+        assert hashes[0] == "fakehash1"
+        assert hashes[1] == "fakehash2"
         assert mock_hash.call_count == 2
 
         # Second access should not re-call the hash function
@@ -204,19 +199,18 @@ class TestStatsAndHasesProperties:
         file1, file2 = tmp_file_pair
 
         lfs = LocalFileStatistics(files=[file1, file2])
-        assert lfs._stat_cache == {}
 
         stats = lfs.stats
 
         # Check keys match
-        assert set(stats.keys()) == {file1.absolute(), file2.absolute()}
+        assert set(lfs.paths) == {file1.absolute(), file2.absolute()}
 
         # Check values are stat_result instances
-        for stat in stats.values():
+        for stat in stats:
             assert isinstance(stat, os.stat_result)
 
         # Check second access returns same object (i.e. no recomputation)
-        assert lfs.stats is stats
+        assert lfs.stats == stats
 
 
 class TestValidate:


### PR DESCRIPTION
I did a little more on top of your recent edit to put the logic for stat/hash onto FileInfo itself and treat LocalFileStats as more of a collection. LMK if this makes sense or is counterproductive to the end use (which I'm admittedly not too familiar with). I think the biggest potential changes that maybe do something I didn't intend are that (a) paths get `.absolute()`ed on ingest, and (b) there is maybe something with the caching and lazy-hashing/stating that I slightly altered compared to before.

I didn't clean up docstrings/comments, and there's a number of ways we could organize the data in terms of lists/dicts/etc.